### PR TITLE
Revert "merge imagemaker code to generate"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 */utgaard/*
 */ymir/*
 */ess/*
-*/data/*
 
 # python specific
 __pycache__/

--- a/dashboard/generate.py
+++ b/dashboard/generate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import htmlsvg, html
+import htmlsvg
 import random, socket, subprocess, os, time, json
 from datetime import datetime
 import argparse
@@ -62,27 +62,16 @@ class Monitor:
         self.s_stage2  = 0x02
         self.s_stage1  = 0x01
         self.lab = serverlist
-        self.buffer = ""
         self.debug = args.debug
         self.refresh = args.refresh
         self.test = args.test
         self.directory = args.out
         self.starttime = self.gettime()
 
+
     def mprint(self, arg):
-        self.buffer += arg + "\n"
+        self.file.write(arg + '\n')
 
-    def flush(self):
-        svg_content = self.extract_svg(self.buffer)
-
-        with open(f"{self.directory}/dashboard.svg", 'w') as file:
-            for svg in svg_content:
-                file.write(svg)
-
-        with open(f"{self.directory}/index.html", "w") as file:
-            file.write(self.buffer)
-        
-        self.buffer = ""
 
     def dprint(self, arg):
         if self.debug:
@@ -100,6 +89,7 @@ class Monitor:
 
     def can_ping(self, status):
         return status & self.s_ping
+
 
     def has_service(self, status):
         return status & self.s_service
@@ -258,7 +248,7 @@ class Monitor:
 
 
     def makelegend(self):
-        common = '<text class="names" x="630" fohtmlnt-size="8px"'
+        common = '<text class="names" x="630" font-size="8px"'
         self.printbox(600, 50, 0, col1, 0)
         self.mprint('{}  y="57"  >uncommissioned</text>'.format(common))
         self.printbox(600, 65, 0, col2, 0)
@@ -274,9 +264,6 @@ class Monitor:
 
 
     def generatesvg(self):
-
-        svg_buffer = ""
-
         self.mprint(htmlsvg.header)
         name = os.path.basename(os.path.normpath(self.directory))
         self.mprint(f'<text x="350" y="12" fill="white" font-size="36px">{name.upper()}</text>')
@@ -295,7 +282,7 @@ class Monitor:
         for name, type, status, ip, port, angle, xo, yo, url, sw in self.lab.servers:
             self.dprint("{} {} {} {}".format(name, type, status, ip))
             if (url != "none"):
-                self.mprint('<a href="{}" target="_blank">'.format(html.escape(url)))
+                self.mprint('<a href="{}" target="_blank">'.format(url))
             mouseovertext = '{}:{}<br>{}'.format(ip, port, sw)
             self.printinst(name, mouseovertext, type, status, angle, xo, yo)
             if (url != "none"):
@@ -307,27 +294,13 @@ class Monitor:
 
         self.mprint(htmlsvg.footer)
 
-        # Write the svg to the file
-        self.mprint(svg_buffer)
-
-    def extract_svg(self, html_content):
-        svgs = []
-        while '<svg' in html_content:
-            start_index = html_content.index('<svg')
-            end_index = html_content.index('</svg>') + len('</svg>')
-            svg = html_content[start_index:end_index]
-            svg = svg.replace('<svg ', '<svg style="background-color:white;" ')
-            svg = svg.replace('<br>', '&#10;')
-            svg = svg.replace('&var-server', '&#38;var-server')
-            svg = svg.replace('&nbsp;', '&#160;')
-            svgs.append(svg)
-            html_content = html_content[end_index:]
-        return svgs
 
     def one_pass(self):
+        self.file = open(f"{self.directory}/tmp.svg", "w")
         self.getstatus()
         self.generatesvg()
-        self.flush()
+        self.file.close()
+        os.rename(f"{self.directory}/tmp.svg", f"{self.directory}/index.html")
 
     def run(self):
         while (True):


### PR DESCRIPTION
Reverts ess-dmsc/server-dashboard#21

Hey guys, 

There are at least two reasons why I revert this:
1) There was a reason why I implemented this they way I did. The move (mv) operation is atomic
so this ensures the whole file is copied over. The new approach seems cleaner but isn't
2) We will redesign the dashboard code sometime soon, so there is not a good reason to make this 
change at this point.
M
