### PR TITLE
remove forced browser border from page

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2,6 +2,13 @@
 
 <head>
   <style>
+    body,
+    img {
+      border: none;
+      margin: 0;
+      outline: none;
+      width: 100%;
+    }
     #tooltip {
       background: cornsilk;
       border: 1px solid black;


### PR DESCRIPTION
As title - by default browsers add an 8px border to the frame.  To better get it to match up with DMSC integraion we override the borders here.